### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/octo.rb
+++ b/Formula/octo.rb
@@ -3,7 +3,6 @@ class Octo < Formula
   desc "Toolbelt for your AWS ASGs"
   homepage "http://github.com/faizalzakaria"
   version "1.0.5"
-  bottle :unneeded
 
   if OS.mac?
     url "http://github.com/faizalzakaria/octo/releases/download/v1.0.5/octo_1.0.5_Darwin_x86_64.tar.gz"
@@ -14,7 +13,7 @@ class Octo < Formula
       sha256 "07075773da42d8a101fc661703a3ff3766d30fe665f83d9ec6a64c7c62792b45"
     end
   end
-  
+
   depends_on "git"
 
   def install


### PR DESCRIPTION
Currently whenever a user call `brew tap faizalzakaria/homebrew-tap`, it failed with following errors:

```
Error: Invalid formula: /opt/homebrew/Library/Taps/faizalzakaria/homebrew-tap/Formula/octo.rb
octo: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the faizalzakaria/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/faizalzakaria/homebrew-tap/Formula/octo.rb:6
```